### PR TITLE
Remove focus on tab blur

### DIFF
--- a/lib/tab.js
+++ b/lib/tab.js
@@ -34,6 +34,12 @@ module.exports = React.createClass({
 		syncNodeAttributes(this.getDOMNode(), this.props);
 	},
 
+	handleBlur: function() {
+		if (typeof this.props.onBlur === 'function') {
+			this.props.onBlur(this.props.id);
+		}
+	},
+
 	render: function () {
 		// Attributes
 		var ariaSelected = this.props.selected ? 'true' : 'false',
@@ -45,7 +51,8 @@ module.exports = React.createClass({
 				id={this.props.id}
 				aria-selected={ariaSelected}
 				aria-expanded={ariaExpanded}
-				aria-controls={ariaControls}>{this.props.children}</li>
+				aria-controls={ariaControls}
+				onBlur={this.handleBlur}>{this.props.children}</li>
 		);
 	}
 });

--- a/lib/tabs.js
+++ b/lib/tabs.js
@@ -143,11 +143,18 @@ module.exports = React.createClass({
 		}
 	},
 
+	removeFocus: function() {
+		this.setState({
+			focus: false
+		});
+	},
+
 	render: function () {
 		var index = 0,
 			count = 0,
 			children,
-			state = this.state;
+			state = this.state,
+			removeFocus = this.removeFocus;
 
 		// Map children to dynamically setup refs
 		children = React.Children.map(this.props.children, function (child) {
@@ -171,7 +178,8 @@ module.exports = React.createClass({
 							id: id,
 							panelId: panelId,
 							selected: selected,
-							focus: focus
+							focus: focus,
+							onBlur: removeFocus
 						});
 					})
 				});


### PR DESCRIPTION
Given a component like this:
```js
var MyComponent = React.createClass({
  getInitialState: function() {
    return {
      val: ""
    };
  },

  handleChange: function(e) {
    this.setState({
      val: e.target.value
    });
  },

  render: function() {
    return (
      <div>
        <input type="text" value={this.state.val} onChange={this.handleChange} />
        <Tabs>
          <TabList>
            <Tab>First</Tab>
            <Tab>Second</Tab>
          </TabList>
          <TabPanel><p>This is the first panel</p></TabPanel>
          <TabPanel><p>Hooray! You found the second panel!</p></TabPanel>
        </Tabs>
      </div>
    );
  }
});
```

Once the user uses the keyboard to change the selected tab, the `focus` state will always be true. This means that if the user focuses on the tabs, changes the current tab via an arrow key on the keyboard, then returns focus to the input field, any key press in the input field will return focus to the currently selected tab.

It happens because, when the component is re-rendered, the `focus` state of `Tabs` is still `true`, despite the focus not being on any of the tabs, so the currently shown tab focuses on itself.

This change sets the `focus` state to `false` when a tab loses focus. One downside is that it seems to always flip `focus` back to `false`, even when selecting different tabs with the keyboard (since one tab is losing focus and another is gaining it). However, `focus` is `true` long enough that the newly selected tab will receive focus before the `focus` state is set back to `false`. Without this change (or some other change that fixes the focus stealing problem), any time the parent component re-renders after a tab is selected using the keyboard, the focus is stolen by the selected tab, making for a very poor user experience.