### PR TITLE
Add Reactify transform for Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "a11y",
     "react-component"
   ],
+  "browserify": {
+    "transform": [ "reactify" ]
+  },
   "devDependencies": {
     "envify": "^3.2.0",
     "jsx-loader": "^0.12.2",


### PR DESCRIPTION
This fixes an unexpected token error when requiring react-tabs in browserify.