### PR TITLE
remove duplicate object property from styles hash

### DIFF
--- a/lib/helpers/styles.js
+++ b/lib/helpers/styles.js
@@ -14,7 +14,6 @@ module.exports = {
     'list-style': 'none',
     'padding': '6px 12px',
     'cursor': 'pointer',
-    'position': 'relative'
   },
 
   '.react-tabs [role=tab][aria-selected=true]': {


### PR DESCRIPTION
A duplicate object property throws in strict mode.