### PR TITLE
Add array to children propTypes

### DIFF
--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -23,6 +23,7 @@ module.exports = React.createClass({
     disabled: PropTypes.bool,
     panelId: PropTypes.string,
     children: PropTypes.oneOfType([
+      PropTypes.array,
       PropTypes.object,
       PropTypes.string
     ])

--- a/lib/components/TabPanel.js
+++ b/lib/components/TabPanel.js
@@ -9,6 +9,7 @@ module.exports = React.createClass({
     id: PropTypes.string,
     tabId: PropTypes.string,
     children: PropTypes.oneOfType([
+      PropTypes.array,
       PropTypes.object,
       PropTypes.string
     ])


### PR DESCRIPTION
I was getting `Warning: Failed propType: Invalid prop `children` supplied to `TabPanel`.` in development. 

This eliminates prevents that error by adding `array` to the list of acceptable `propTypes` for `children`.