### PR TITLE
Allow disabling of included Stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ var App = React.createClass({
         tab's contents. Setting `forceRenderTabPanel` to `true` allows you to override the
         default behavior, which may be useful in some circumstances (such as animating between tabs).
 
+        `loadStylesheet` Allows enabling/disabling the included stylesheet that
+        comes with this package. Setting `loadStylesheet` to `true` will use
+        the external package `js-stylesheet` to load the included stylesheet. By
+        default this is set to `true`.
+
       */}
 
       <Tabs

--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -22,7 +22,8 @@ module.exports = React.createClass({
 		onSelect: PropTypes.func,
 		focus: PropTypes.bool,
     children: childrenPropType,
-    forceRenderTabPanel: PropTypes.bool
+    forceRenderTabPanel: PropTypes.bool,
+    loadStylesheet: PropTypes.bool
 	},
 
   childContextTypes: {
@@ -33,7 +34,8 @@ module.exports = React.createClass({
 		return {
 			selectedIndex: -1,
 			focus: false,
-      forceRenderTabPanel: false
+      forceRenderTabPanel: false,
+      loadStylesheet: true
 		};
 	},
 
@@ -48,7 +50,9 @@ module.exports = React.createClass({
   },
 
 	componentWillMount() {
-    jss(require('../helpers/styles.js'));
+    if (this.props.loadStylesheet) {
+      jss(require('../helpers/styles.js'));
+    }
 	},
 
   componentWillReceiveProps(newProps) {


### PR DESCRIPTION
I know that it is possible to override the included stylesheets, but we wanted to remove the overhead of loading the included stylesheet at all.

In my opinion it would still be a better solution to remove the loading of stylesheets completely, as I think it is kinda unexpected that some library-components - loaded through npm - start loading there own css (in ways you might not want it in your project). The default-style could still be part as an example plain-css file and/or js-stylesheet file for folks that want to use that. (e.g. ```jss(require('react-tabs').Stylesheet)```)

What yo you think about that? You probably had an idea on why to integrate the styling in the components, right?